### PR TITLE
Add setting to attenuate output while speaking

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -69,6 +69,9 @@ public class Settings {
 
     public static final String PREF_AMPLITUDE_BOOST = "inputVolume";
     public static final Integer DEFAULT_AMPLITUDE_BOOST = 100;
+    
+    public static final String PREF_ATTENUATE_OTHERS = "attenuateOthers";
+    public static final Integer DEFAULT_ATTENUATE_OTHERS = 0;
 
     public static final String PREF_CHAT_NOTIFY = "chatNotify";
     public static final Boolean DEFAULT_CHAT_NOTIFY = true;
@@ -142,6 +145,10 @@ public class Settings {
 
     public float getAmplitudeBoostMultiplier() {
         return (float)preferences.getInt(Settings.PREF_AMPLITUDE_BOOST, DEFAULT_AMPLITUDE_BOOST)/100;
+    }
+    
+    public float getAttenuateOthers() {
+        return (float)preferences.getInt(Settings.PREF_ATTENUATE_OTHERS, DEFAULT_ATTENUATE_OTHERS)/100;
     }
 
     public float getDetectionThreshold() {

--- a/app/src/main/res/values/preference.xml
+++ b/app/src/main/res/values/preference.xml
@@ -79,6 +79,8 @@
 	<string name="audioInputMethod">Transmit Mode</string>
     <string name="audioInputVolume">Microphone Volume</string>
     <string name="audioInputVolumeSum">Microphone volume multiplier used to artificially normalize audio.</string>
+    <string name="audioAttenuateOthers">Attenuate Others</string>
+    <string name="audioAttenuateOthersSum">Lower output volume by this percentage when you speak.</string>
 	<string name="callMode">Call Mode</string>
 	<string name="callModeSum">The call mode of Plumble, whether to act as a voice call or speakerphone.</string>
 	<string name="detectionThreshold">Detection Threshold</string>

--- a/app/src/main/res/xml/settings_audio.xml
+++ b/app/src/main/res/xml/settings_audio.xml
@@ -33,6 +33,14 @@
         max="200"
         android:defaultValue="100"
         android:text="%"/>
+    
+    <com.morlunk.mumbleclient.preference.SeekBarDialogPreference
+        android:title="@string/audioAttenuateOthers"
+        android:summary="@string/audioAttenuateOthersSum"
+        android:key="attenuateOthers"
+        max="100"
+        android:defaultValue="0"
+        android:text="%"/>
 
     <PreferenceCategory android:title="@string/voiceActivitySettings"
         android:key="vad_settings">


### PR DESCRIPTION
On some handsets the audio output causes crazy feedback when you speak. This setting lets you lower the volume automatically when you speak to avoid this problem.

I'm still not sure if attenuating or just flat out muting (a checkbox instead of a slider) would be better. On my Gnex handset even at 90% attenuation other people can hear themselves talking while my mic is on. It's not nearly as bad as not lowering the volume at all, though.
