### PR TITLE
Dark theme, background in PopUp

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -164,6 +164,9 @@ public class Settings {
     public static final String PREF_SHOW_USER_COUNT = "show_user_count";
     public static final boolean DEFAULT_SHOW_USER_COUNT = false;
 
+    public static final String PREF_START_UP_IN_PINNED_MODE = "startUpInPinnedMode";
+    public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = true;
+
     static {
         ARRAY_INPUT_METHODS = new HashSet<String>();
         ARRAY_INPUT_METHODS.add(ARRAY_INPUT_METHOD_VOICE);
@@ -448,5 +451,9 @@ public class Settings {
      */
     public boolean shouldShowUserCount() {
         return preferences.getBoolean(PREF_SHOW_USER_COUNT, DEFAULT_SHOW_USER_COUNT);
+    }
+
+    public boolean isStartUpInPinnedMode() {
+        return preferences.getBoolean(PREF_START_UP_IN_PINNED_MODE, DEFAULT_START_UP_IN_PINNED_MODE);
     }
 }

--- a/app/src/main/java/com/morlunk/mumbleclient/app/DrawerAdapter.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/DrawerAdapter.java
@@ -51,9 +51,9 @@ public class DrawerAdapter extends ArrayAdapter<DrawerAdapter.DrawerRow> {
     // Drawer rows, integer value is id
     public static final int HEADER_CONNECTED_SERVER = 0;
     public static final int ITEM_SERVER = 1;
-    public static final int ITEM_INFO = 2;
-    public static final int ITEM_ACCESS_TOKENS = 3;
-    public static final int ITEM_PINNED_CHANNELS = 4;
+    public static final int ITEM_PINNED_CHANNELS = 2;
+    public static final int ITEM_INFO = 3;
+    public static final int ITEM_ACCESS_TOKENS = 4;
     public static final int HEADER_SERVERS = 5;
     public static final int ITEM_FAVOURITES = 6;
 //    public static final int ITEM_LAN = 7;
@@ -99,9 +99,9 @@ public class DrawerAdapter extends ArrayAdapter<DrawerAdapter.DrawerRow> {
         mProvider = provider;
         add(new DrawerAdapter.DrawerHeader(HEADER_CONNECTED_SERVER, context.getString(R.string.drawer_not_connected)));
         add(new DrawerAdapter.DrawerItem(ITEM_SERVER, context.getString(R.string.drawer_server), R.drawable.ic_action_channels));
+        add(new DrawerAdapter.DrawerItem(ITEM_PINNED_CHANNELS, context.getString(R.string.drawer_pinned), R.drawable.ic_action_comment));
         add(new DrawerAdapter.DrawerItem(ITEM_INFO, context.getString(R.string.information), R.drawable.ic_action_info_dark));
         add(new DrawerAdapter.DrawerItem(ITEM_ACCESS_TOKENS, context.getString(R.string.drawer_tokens), R.drawable.ic_action_save));
-        add(new DrawerAdapter.DrawerItem(ITEM_PINNED_CHANNELS, context.getString(R.string.drawer_pinned), R.drawable.ic_action_comment));
         add(new DrawerAdapter.DrawerHeader(HEADER_SERVERS, context.getString(R.string.drawer_header_servers)));
         add(new DrawerAdapter.DrawerItem(ITEM_FAVOURITES, context.getString(R.string.drawer_favorites), R.drawable.ic_action_favourite_on));
 //        add(new DrawerAdapter.DrawerItem(ITEM_LAN, context.getString(R.string.drawer_lan), R.drawable.ic_action_fullscreen)); // Coming soon, TODO

--- a/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
@@ -146,7 +146,12 @@ public class PlumbleActivity extends ActionBarActivity implements ListView.OnIte
     private JumbleObserver mObserver = new JumbleObserver() {
         @Override
         public void onConnected() {
-            loadDrawerFragment(DrawerAdapter.ITEM_SERVER);
+            if (mSettings.isStartUpInPinnedMode()) {
+                loadDrawerFragment(DrawerAdapter.ITEM_PINNED_CHANNELS);
+            } else {
+                loadDrawerFragment(DrawerAdapter.ITEM_SERVER);
+            }
+
             mDrawerAdapter.notifyDataSetChanged();
             supportInvalidateOptionsMenu();
 

--- a/app/src/main/res/values/preference.xml
+++ b/app/src/main/res/values/preference.xml
@@ -131,4 +131,6 @@
     <string name="pref_export_certificate_summary">Exports a certificate to external storage.</string>
     <string name="pref_show_user_count">Show Channel User Count</string>
     <string name="pref_show_user_count_summary">Show a counter with the number of users in a channel subtree.</string>
+    <string name="pref_startUpInPinnedMode">Start Up In Pinned Mode</string>
+    <string name="pref_startUpInPinnedModeSum">When connecting to a server, only the pinned channels will be displayed</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>
     <string name="drawer_not_connected">Not Connected</string>
-    <string name="drawer_server">Server</string>
+    <string name="drawer_server">All Channels</string>
     <string name="drawer_info">Information</string>
     <string name="drawer_tokens">Access Tokens</string>
     <string name="drawer_pinned">Pinned Channels</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -43,8 +43,7 @@
         <item name="android:textColorSecondary">#DDD</item>
         <item name="android:textColorPrimaryInverse">#FFF</item>
         <item name="android:textColorSecondaryInverse">#AAA</item>
-        <item name="android:windowBackground">@android:color/black</item>
-        <item name="android:colorBackground">@android:color/black</item>
+
 
         <item name="android:actionBarStyle">@style/PlumbleDarkActionBar</item>
         <item name="actionBarStyle">@style/PlumbleDarkActionBar</item>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -65,4 +65,12 @@
         android:key="useTor"
         android:summary="@string/useTorSum"
         android:title="@string/useTor"/>
+
+    <CheckBoxPreference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="false"
+        android:key="startUpInPinnedMode"
+        android:summary="@string/pref_startUpInPinnedModeSum"
+        android:title="@string/pref_startUpInPinnedMode" />
 </PreferenceScreen>


### PR DESCRIPTION
Setting the background to completely black in material design, makes it impossible to see where a popup windows are.

 So the 2 background colors in Dark theme could preferable be removed.