### PR TITLE
Login "StartUpInPinnedMode" Setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 apply plugin: 'com.android.application'
@@ -48,7 +48,7 @@ if (signingFile.exists()) apply from: 'signing.gradle'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 12

--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -165,11 +165,7 @@ public class Settings {
     public static final boolean DEFAULT_SHOW_USER_COUNT = false;
 
     public static final String PREF_START_UP_IN_PINNED_MODE = "startUpInPinnedMode";
-<<<<<<< HEAD
     public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = false;
-=======
-    public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = true;
->>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
 
     static {
         ARRAY_INPUT_METHODS = new HashSet<String>();
@@ -457,11 +453,7 @@ public class Settings {
         return preferences.getBoolean(PREF_SHOW_USER_COUNT, DEFAULT_SHOW_USER_COUNT);
     }
 
-<<<<<<< HEAD
     public boolean shouldStartUpInPinnedMode() {
-=======
-    public boolean isStartUpInPinnedMode() {
->>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
         return preferences.getBoolean(PREF_START_UP_IN_PINNED_MODE, DEFAULT_START_UP_IN_PINNED_MODE);
     }
 }

--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -164,6 +164,9 @@ public class Settings {
     public static final String PREF_SHOW_USER_COUNT = "show_user_count";
     public static final boolean DEFAULT_SHOW_USER_COUNT = false;
 
+    public static final String PREF_START_UP_IN_PINNED_MODE = "startUpInPinnedMode";
+    public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = false;
+
     static {
         ARRAY_INPUT_METHODS = new HashSet<String>();
         ARRAY_INPUT_METHODS.add(ARRAY_INPUT_METHOD_VOICE);
@@ -448,5 +451,9 @@ public class Settings {
      */
     public boolean shouldShowUserCount() {
         return preferences.getBoolean(PREF_SHOW_USER_COUNT, DEFAULT_SHOW_USER_COUNT);
+    }
+
+    public boolean shouldStartUpInPinnedMode() {
+        return preferences.getBoolean(PREF_START_UP_IN_PINNED_MODE, DEFAULT_START_UP_IN_PINNED_MODE);
     }
 }

--- a/app/src/main/java/com/morlunk/mumbleclient/Settings.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/Settings.java
@@ -165,7 +165,11 @@ public class Settings {
     public static final boolean DEFAULT_SHOW_USER_COUNT = false;
 
     public static final String PREF_START_UP_IN_PINNED_MODE = "startUpInPinnedMode";
+<<<<<<< HEAD
     public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = false;
+=======
+    public static final boolean DEFAULT_START_UP_IN_PINNED_MODE = true;
+>>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
 
     static {
         ARRAY_INPUT_METHODS = new HashSet<String>();
@@ -453,7 +457,11 @@ public class Settings {
         return preferences.getBoolean(PREF_SHOW_USER_COUNT, DEFAULT_SHOW_USER_COUNT);
     }
 
+<<<<<<< HEAD
     public boolean shouldStartUpInPinnedMode() {
+=======
+    public boolean isStartUpInPinnedMode() {
+>>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
         return preferences.getBoolean(PREF_START_UP_IN_PINNED_MODE, DEFAULT_START_UP_IN_PINNED_MODE);
     }
 }

--- a/app/src/main/java/com/morlunk/mumbleclient/app/DrawerAdapter.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/DrawerAdapter.java
@@ -51,9 +51,9 @@ public class DrawerAdapter extends ArrayAdapter<DrawerAdapter.DrawerRow> {
     // Drawer rows, integer value is id
     public static final int HEADER_CONNECTED_SERVER = 0;
     public static final int ITEM_SERVER = 1;
-    public static final int ITEM_INFO = 2;
-    public static final int ITEM_ACCESS_TOKENS = 3;
-    public static final int ITEM_PINNED_CHANNELS = 4;
+    public static final int ITEM_PINNED_CHANNELS = 2;
+    public static final int ITEM_INFO = 3;
+    public static final int ITEM_ACCESS_TOKENS = 4;
     public static final int HEADER_SERVERS = 5;
     public static final int ITEM_FAVOURITES = 6;
 //    public static final int ITEM_LAN = 7;
@@ -99,9 +99,9 @@ public class DrawerAdapter extends ArrayAdapter<DrawerAdapter.DrawerRow> {
         mProvider = provider;
         add(new DrawerAdapter.DrawerHeader(HEADER_CONNECTED_SERVER, context.getString(R.string.drawer_not_connected)));
         add(new DrawerAdapter.DrawerItem(ITEM_SERVER, context.getString(R.string.drawer_server), R.drawable.ic_action_channels));
+        add(new DrawerAdapter.DrawerItem(ITEM_PINNED_CHANNELS, context.getString(R.string.drawer_pinned), R.drawable.ic_action_comment));
         add(new DrawerAdapter.DrawerItem(ITEM_INFO, context.getString(R.string.information), R.drawable.ic_action_info_dark));
         add(new DrawerAdapter.DrawerItem(ITEM_ACCESS_TOKENS, context.getString(R.string.drawer_tokens), R.drawable.ic_action_save));
-        add(new DrawerAdapter.DrawerItem(ITEM_PINNED_CHANNELS, context.getString(R.string.drawer_pinned), R.drawable.ic_action_comment));
         add(new DrawerAdapter.DrawerHeader(HEADER_SERVERS, context.getString(R.string.drawer_header_servers)));
         add(new DrawerAdapter.DrawerItem(ITEM_FAVOURITES, context.getString(R.string.drawer_favorites), R.drawable.ic_action_favourite_on));
 //        add(new DrawerAdapter.DrawerItem(ITEM_LAN, context.getString(R.string.drawer_lan), R.drawable.ic_action_fullscreen)); // Coming soon, TODO

--- a/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
@@ -146,7 +146,12 @@ public class PlumbleActivity extends ActionBarActivity implements ListView.OnIte
     private JumbleObserver mObserver = new JumbleObserver() {
         @Override
         public void onConnected() {
-            loadDrawerFragment(DrawerAdapter.ITEM_SERVER);
+            if (mSettings.isStartUpInPinnedMode()) {
+                loadDrawerFragment(DrawerAdapter.ITEM_PINNED_CHANNELS);
+            } else {
+                loadDrawerFragment(DrawerAdapter.ITEM_SERVER);
+            }
+
             mDrawerAdapter.notifyDataSetChanged();
             supportInvalidateOptionsMenu();
 

--- a/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
@@ -145,7 +145,11 @@ public class PlumbleActivity extends ActionBarActivity implements ListView.OnIte
     private JumbleObserver mObserver = new JumbleObserver() {
         @Override
         public void onConnected() {
+<<<<<<< HEAD
             if (mSettings.shouldStartUpInPinnedMode()) {
+=======
+            if (mSettings.isStartUpInPinnedMode()) {
+>>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
                 loadDrawerFragment(DrawerAdapter.ITEM_PINNED_CHANNELS);
             } else {
                 loadDrawerFragment(DrawerAdapter.ITEM_SERVER);

--- a/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/app/PlumbleActivity.java
@@ -53,7 +53,6 @@ import com.morlunk.jumble.IJumbleService;
 import com.morlunk.jumble.IJumbleSession;
 import com.morlunk.jumble.model.Server;
 import com.morlunk.jumble.protobuf.Mumble;
-import com.morlunk.jumble.util.JumbleDisconnectedException;
 import com.morlunk.jumble.util.JumbleException;
 import com.morlunk.jumble.util.JumbleObserver;
 import com.morlunk.jumble.util.MumbleURLParser;
@@ -146,7 +145,7 @@ public class PlumbleActivity extends ActionBarActivity implements ListView.OnIte
     private JumbleObserver mObserver = new JumbleObserver() {
         @Override
         public void onConnected() {
-            if (mSettings.isStartUpInPinnedMode()) {
+            if (mSettings.shouldStartUpInPinnedMode()) {
                 loadDrawerFragment(DrawerAdapter.ITEM_PINNED_CHANNELS);
             } else {
                 loadDrawerFragment(DrawerAdapter.ITEM_SERVER);

--- a/app/src/main/res/values/preference.xml
+++ b/app/src/main/res/values/preference.xml
@@ -131,4 +131,6 @@
     <string name="pref_export_certificate_summary">Exports a certificate to external storage.</string>
     <string name="pref_show_user_count">Show Channel User Count</string>
     <string name="pref_show_user_count_summary">Show a counter with the number of users in a channel subtree.</string>
+    <string name="pref_start_up_in_pinned_mode">Start Up In Pinned Mode</string>
+    <string name="pref_start_up_in_pinned_mode_sum">When connecting to a server, only the pinned channels will be displayed.</string>
 </resources>

--- a/app/src/main/res/values/preference.xml
+++ b/app/src/main/res/values/preference.xml
@@ -131,6 +131,11 @@
     <string name="pref_export_certificate_summary">Exports a certificate to external storage.</string>
     <string name="pref_show_user_count">Show Channel User Count</string>
     <string name="pref_show_user_count_summary">Show a counter with the number of users in a channel subtree.</string>
+<<<<<<< HEAD
     <string name="pref_start_up_in_pinned_mode">Start Up In Pinned Mode</string>
     <string name="pref_start_up_in_pinned_mode_sum">When connecting to a server, only the pinned channels will be displayed.</string>
+=======
+    <string name="pref_startUpInPinnedMode">Start Up In Pinned Mode</string>
+    <string name="pref_startUpInPinnedModeSum">When connecting to a server, only the pinned channels will be displayed</string>
+>>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>
     <string name="drawer_not_connected">Not Connected</string>
-    <string name="drawer_server">Server</string>
+    <string name="drawer_server">All Channels</string>
     <string name="drawer_info">Information</string>
     <string name="drawer_tokens">Access Tokens</string>
     <string name="drawer_pinned">Pinned Channels</string>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -71,6 +71,11 @@
         android:layout_height="wrap_content"
         android:defaultValue="false"
         android:key="startUpInPinnedMode"
+<<<<<<< HEAD
         android:summary="@string/pref_start_up_in_pinned_mode_sum"
         android:title="@string/pref_start_up_in_pinned_mode" />
+=======
+        android:summary="@string/pref_startUpInPinnedModeSum"
+        android:title="@string/pref_startUpInPinnedMode" />
+>>>>>>> 9b6844c89531b6ae3e8cc7b10f4421ce0d7502a8
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -65,4 +65,12 @@
         android:key="useTor"
         android:summary="@string/useTorSum"
         android:title="@string/useTor"/>
+
+    <CheckBoxPreference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="false"
+        android:key="startUpInPinnedMode"
+        android:summary="@string/pref_start_up_in_pinned_mode_sum"
+        android:title="@string/pref_start_up_in_pinned_mode" />
 </PreferenceScreen>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 18 18:48:19 PDT 2016
+#Mon Aug 21 20:22:14 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
When connecting to a server this setting makes it possible to start in pinned mode, especially when the server is large or the user is a non tech, this can be usefull.
A new checkbox in settiolngs->general is added.

Added in RES->XML->settings_general.xml:
a new Checkbox called "startupInPinnedMode”

Added in settings.java:
PREF_START_UP_IN_PINNED_MODE
DEFAULT_START_UP_IN_PINNED_MODE
isStartUpInPinnedMode()

Added in res->values->preferences.xml:
pref_startUpInPinnedMode
pref_startUpInPinnedModeSum

Added in app->PlumbleActivity->JumbleObserver->OnConnected():
status check of mSettings.isStartUpInPinnedMode

-----------------------------

 The Drawermenu has 2 changes to make it more logical.
1: Label Server is changed to "All Channels”
2: Order of menu is changed so "Pinned Channels" are the second item.

Changed in res->value->strings.xml:
drawer_server default label changed from "Server" to "All Channels”

Changed in app->DrawerAdaptor:
placement/order of add(new DrawerAdapter.DrawerItem(ITEM_PINNED_CHANNELS, context.getString(R.string.drawer_pinned), R.drawable.ic_action_comment));
Order of ITEM_PINNED_CHANNELS, ITEM_INFO, ITEM_ACCESS_TOKENS