### PR TITLE
Dark theme, background color in PopUpWindow 

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -43,8 +43,7 @@
         <item name="android:textColorSecondary">#DDD</item>
         <item name="android:textColorPrimaryInverse">#FFF</item>
         <item name="android:textColorSecondaryInverse">#AAA</item>
-        <item name="android:windowBackground">@android:color/black</item>
-        <item name="android:colorBackground">@android:color/black</item>
+
 
         <item name="android:actionBarStyle">@style/PlumbleDarkActionBar</item>
         <item name="actionBarStyle">@style/PlumbleDarkActionBar</item>


### PR DESCRIPTION
Setting the background to completely black in material design, makes it impossible to see where a popup windows are.

 So the 2 background colors in Dark theme could preferable be removed.