### PR TITLE
ChannelRow - 18sp bold font & Push To Talk - 18sp red font

### DIFF
--- a/app/src/main/res/layout/channel_row.xml
+++ b/app/src/main/res/layout/channel_row.xml
@@ -41,7 +41,10 @@
         android:gravity="center_vertical|left"
         android:minHeight="48dp"
         android:padding="4dp"
-        android:text="Channel name\nLine 2\nLine 3\nLine 4"/>
+        android:text="Channel name\nLine 2\nLine 3\nLine 4"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:textSize="18sp"
+        />
 
     <TextView
         android:id="@+id/channel_row_count"

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -78,9 +78,9 @@
             android:layout_width="match_parent"
             android:layout_height="50dp"
             android:text="@string/ptt"
-            android:textColor="?android:attr/textColorPrimaryInverse"
+            android:textColor="@color/holo_red_dark"
             android:textStyle="bold"
-            android:textSize="12sp"
+            android:textSize="18sp"
             android:background="?attr/selectableItemBackground"/>
     </LinearLayout>
 


### PR DESCRIPTION
I have tried different things to make it easier to see the difference between channels and users.
One might argue that there should be a little background difference between those, but i think making the ChannelRow text bolder and larger than users row text, does the job pretty well.

I also propose to change the font size of the push to talk text. I propose a red color and 18sp. That looks okay in all themes, and in all "push to area" sizes.