### PR TITLE
Join Channel on text field and use the Chat icon for selecting chat

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/channel/ChannelListAdapter.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/channel/ChannelListAdapter.java
@@ -124,14 +124,6 @@ public class ChannelListAdapter extends RecyclerView.Adapter implements UserMenu
         if (node.isChannel()) {
             final IChannel channel = node.getChannel();
             final ChannelViewHolder cvh = (ChannelViewHolder) viewHolder;
-            cvh.itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (mChannelClickListener != null) {
-                        mChannelClickListener.onChannelClick(channel);
-                    }
-                }
-            });
 
             final boolean expandUsable = channel.getSubchannels().size() > 0 ||
                     channel.getSubchannelUserCount() > 0;
@@ -185,11 +177,14 @@ public class ChannelListAdapter extends RecyclerView.Adapter implements UserMenu
                     cvh.mChannelHolder.getPaddingRight(),
                     cvh.mChannelHolder.getPaddingBottom());
 
-            cvh.mJoinButton.setOnClickListener(new View.OnClickListener() {
+            // Actions.
+
+            cvh.mChatChannelButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (mService.isConnected())
-                        mService.getSession().joinChannel(channel.getId());
+                    if (mChannelClickListener != null) {
+                        mChannelClickListener.onChannelClick(channel);
+                    }
                 }
             });
 
@@ -201,9 +196,18 @@ public class ChannelListAdapter extends RecyclerView.Adapter implements UserMenu
                 }
             });
 
+            cvh.itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mService.isConnected())
+                        mService.getSession().joinChannel(channel.getId());
+                }
+
+            });
             cvh.itemView.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
+                    //ToDo: olzzon Long Click join Channel - Setting Secure Channel Shift
                     cvh.mMoreButton.performClick();
                     return true;
                 }
@@ -516,7 +520,7 @@ public class ChannelListAdapter extends RecyclerView.Adapter implements UserMenu
         public ImageView mChannelExpandToggle;
         public TextView mChannelName;
         public TextView mChannelUserCount;
-        public ImageView mJoinButton;
+        public ImageView mChatChannelButton;
         public ImageView mMoreButton;
 
         public ChannelViewHolder(View itemView) {
@@ -525,7 +529,7 @@ public class ChannelListAdapter extends RecyclerView.Adapter implements UserMenu
             mChannelExpandToggle = (ImageView) itemView.findViewById(R.id.channel_row_expand);
             mChannelName = (TextView) itemView.findViewById(R.id.channel_row_name);
             mChannelUserCount = (TextView) itemView.findViewById(R.id.channel_row_count);
-            mJoinButton = (ImageView) itemView.findViewById(R.id.channel_row_join);
+            mChatChannelButton = (ImageView) itemView.findViewById(R.id.channel_row_join);
             mMoreButton = (ImageView) itemView.findViewById(R.id.channel_row_more);
         }
     }

--- a/app/src/main/res/layout/channel_row.xml
+++ b/app/src/main/res/layout/channel_row.xml
@@ -37,7 +37,7 @@
         android:id="@+id/channel_row_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
+        android:layout_weight="0.77"
         android:gravity="center_vertical|left"
         android:minHeight="48dp"
         android:padding="4dp"
@@ -48,17 +48,17 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center"
+        android:padding="10dp"
         android:text="10"
-        android:textStyle="bold"
-        android:padding="10dp"/>
+        android:textStyle="bold" />
 
     <ImageView
         android:id="@+id/channel_row_join"
-        android:layout_width="32dp"
+        android:layout_width="22dp"
         android:layout_height="match_parent"
-        android:src="@drawable/ic_action_move"
-        android:tint="?android:attr/textColorSecondary"
-        android:background="?attr/selectableItemBackgroundBorderless"/>
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/sym_action_chat"
+        android:tint="?android:attr/textColorSecondary" />
 
     <ImageView
         android:id="@+id/channel_row_more"

--- a/app/src/main/res/layout/channel_row.xml
+++ b/app/src/main/res/layout/channel_row.xml
@@ -37,11 +37,14 @@
         android:id="@+id/channel_row_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="0.77"
+        android:layout_weight="1"
         android:gravity="center_vertical|left"
         android:minHeight="48dp"
         android:padding="4dp"
-        android:text="Channel name\nLine 2\nLine 3\nLine 4"/>
+        android:text="Channel name\nLine 2\nLine 3\nLine 4"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:textSize="18sp"
+        />
 
     <TextView
         android:id="@+id/channel_row_count"

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -78,9 +78,9 @@
             android:layout_width="match_parent"
             android:layout_height="50dp"
             android:text="@string/ptt"
-            android:textColor="?android:attr/textColorPrimaryInverse"
+            android:textColor="@color/holo_red_dark"
             android:textStyle="bold"
-            android:textSize="12sp"
+            android:textSize="18sp"
             android:background="?attr/selectableItemBackground"/>
     </LinearLayout>
 


### PR DESCRIPTION
This is a proposal that change the behavior of the Channel Row.
The Join arrow is removed and a chat bubble is added instead.

So now you press the text of the channel to join it (cvh.itemView.setOnClickListener), and press the Chat bubble to join the Chat channel.

If someone want a more safe join channel, an option in settings->general called something like "safe join channel" could be added, that sets long press click on text to join channel, and short channel click does nothing. (cvh.itenView.senOnLongClickListener joins channel instead of opening the moreMenu)
I´ll gladly incorporate that if wished by someone.

The setOnClickListener is moved down to the other actions so all Channel actions are the same place.

----------

The ChannelRow text are set to 18sp and made Bold so there´s a clear difference between channels and users.
The PushToTalk label are also set to 18sp and made Red. 