### PR TITLE
Fix for JoinChannel scrolls channel list to button Issue#178

### DIFF
--- a/app/src/main/java/com/morlunk/mumbleclient/channel/ChannelListFragment.java
+++ b/app/src/main/java/com/morlunk/mumbleclient/channel/ChannelListFragment.java
@@ -330,14 +330,14 @@ public class ChannelListFragment extends JumbleServiceFragment implements OnChan
 	 */
 	public void scrollToChannel(int channelId) {
 		int channelPosition = mChannelListAdapter.getChannelPosition(channelId);
-        mChannelView.smoothScrollToPosition(channelPosition);
+        mChannelView.scrollToPosition(channelPosition);
     }
 	/**
 	 * Scrolls to the passed user.
 	 */
 	public void scrollToUser(int userId) {
 		int userPosition = mChannelListAdapter.getUserPosition(userId);
-		mChannelView.smoothScrollToPosition(userPosition);
+		mChannelView.scrollToPosition(userPosition);
 	}
 
     private boolean isShowingPinnedChannels() {


### PR DESCRIPTION
(e.g. use public server Libre Antenne)
Using the release candidate from Fdroid 3.3.0rc1:
When joining a channel on a larger server the display scrolls to another place on the list.
So it can be hard to find the group you joined.
The version 3.2.0 in playstore (with the old JoinChannel function) does not have this issue.

Changing mChannelView.smoothScrollToPosition to mChannelView.scrollToPosition (in ChannelListFragment.java->scrollToChannel) solves the problem.

Are there any reasons for using the smoothScrollToPosition instead og scrollToPosition? and do you think it´s because of a certain SDK version?
Otherwise I propose to change it.